### PR TITLE
Remove code from docker file that copies source code at image build time

### DIFF
--- a/RAG/src/chain_server/Dockerfile
+++ b/RAG/src/chain_server/Dockerfile
@@ -38,23 +38,5 @@ RUN python3.10 -m nltk.downloader stopwords
 RUN python3.10 -m nltk.downloader punkt
 RUN python3.10 -c "from sentence_transformers import SentenceTransformer; model = SentenceTransformer('Snowflake/snowflake-arctic-embed-l'); model.save('/tmp-data')"
 
-# Install any example specific dependency if available
-ARG EXAMPLE_PATH
-COPY RAG/examples/${EXAMPLE_PATH} /opt/RAG/examples/${EXAMPLE_PATH}
-RUN if [ -f "/opt/RAG/examples/${EXAMPLE_PATH}/requirements.txt" ] ; then \
-    pip3 install --no-cache-dir -r /opt/RAG/examples/${EXAMPLE_PATH}/requirements.txt ; else \
-    echo "Skipping example dependency installation, since requirements.txt was not found" ; \
-    fi
-
-RUN if [ "${EXAMPLE_PATH}" = "advanced_rag/multimodal_rag" ] ; then \
-    apt update && \
-    apt install -y libreoffice tesseract-ocr ; \
-    fi
-
-# Copy required common modules for all examples
-COPY RAG/src/chain_server /opt/RAG/src/chain_server
-COPY RAG/src/pandasai /opt/RAG/src/pandasai
-COPY RAG/tools /opt/RAG/tools
-
 WORKDIR /opt
 ENTRYPOINT ["uvicorn", "RAG.src.chain_server.server:app"]


### PR DESCRIPTION
No longer copy source code from the RAG sub folder into Docker image. 
Instead, the source code now needs to be pushed into our NGC registry and will be downloaded when the Docker container is deployed on EC2 instances (a separate PR in rag-server-ms handle this: https://github.com/QarlAI/rag-server-ms/pull/3).
The reason for this change is that, right now, in order to make any change to the Python code in the RAG sub folder, we would need to rebuild and re-upload the Docker image, which takes a long time. With this change, the same Docker image can be reused for the foreseeable future, any change to Python source code only needs a quick update of resource in NGC.

This PR is used to build `0510897355631248/dalei_qarl/generativeai-examples:0.0.4` Docker image.

To upload new source code:
```
cd GenerativeAIExamples
ngc registry resource upload-version 0510897355631248/<channel>/rag_ms_source:<version> --source RAG
``` 
Once the source code is uploaded, I recommend a sanity check by redownloading it:
```
ngc registry resource download-version 0510897355631248/<channel>/rag_ms_source:<version>
```
When the download finishes, the log should say:
```
Getting files to download...
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ • 3.7/3.7 MiB • Remaining: 0:00:00 • 394.4 kB/s • Elapsed: 0:00:13 • Total: 182 - Completed: 182 - Failed: 0

---------------------------------------------------------------------------------------
   Download status: COMPLETED
   Downloaded local path resource: /home/dalei/qarl_custom_modules/rag_ms_source_v0.0.3
   Total files downloaded: 182
   Total transferred: 3.67 MB
   Started at: 2025-04-02 08:36:46
   Completed at: 2025-04-02 08:37:00
   Duration taken: 14s
---------------------------------------------------------------------------------------
```
If it says that one or more files failed to download, make sure you didn't re-use `<version>` when uploading. See explanation below.

When uploading source code to NGC, there are two things to pay particular attention to:

- Do **not** recycle `<version>`, I ran into weird problems when I modified some .py file, and pushed into an existing version of  `rag_ms_source`.
- The RAG subfolder must contain `examples`, `tools`, and `src`. You can leave out the other stuff.